### PR TITLE
Remove Bower, simplify local setup, and add reloading static file server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Execute these two `npm` commands to install project dependencies
 
 ```
 npm install
-npm run bower
 ```
 
 To compile the SCSS source to CSS, use
@@ -23,21 +22,15 @@ npm run gulp
 
 This will automatically re-compile your CSS whenever a `.scss` source file changes, but you will still have to manually reload the browser tab to see the change. Auto reload is not present so far.
 
-### Using Bower & Gulp globally
+### Using Gulp globally
 
-This project uses locally-installed build tools & `npm` scripts to simplify setup, but at times it may be beneficial to have full access to build tools like `gulp` or `bower`. If you wish to use these command-line utilities directly, you can install them globally:
+This project uses locally-installed `gulp` & `npm` scripts to simplify setup, but at times it may be beneficial to have direct command-line access to `gulp` itself. You can install the `gulp` CLI using [these "getting started" instructions]((https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
 
-- To install the `bower` command line utility, run `npm install -g bower`.
-- To install the `gulp` command line utility, [follow these Gulp "getting started" instructions]((https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
-
-### Command Reference
-
-This table shows the corresponding `bower` and `gulp` commands for each `npm` command.
+This table shows the corresponding `gulp` commands for each `npm` command:
 
 Task | `npm` command | corresponding CLI command
 ---- | ------------- | -------------------------
 Install NPM dependencies | `npm install` | _n/a_
-Install Bower dependencies | `npm run bower` | `bower install`
 Compile SCSS to CSS | `npm run gulp:styles` | `gulp styles`
 Start Gulp watch task to auto-rebuild SCSS | `npm run gulp` | `gulp`
 

--- a/README.md
+++ b/README.md
@@ -16,21 +16,26 @@ npm run gulp:styles
 
 To watch SCSS files and rebuild the CSS whenever a `.scss` source file changes, use
 
-```sh
+```
 npm run gulp
 ```
 
-This will automatically re-compile your CSS whenever a `.scss` source file changes, but you will still have to manually reload the browser tab to see the change. Auto reload is not present so far.
+### Auto-reloading development server
 
-### Using Gulp globally
+To start a local development server that will auto-rebuild SCSS and reload your page whenever the HTML or styles change, run
 
-This project uses locally-installed `gulp` & `npm` scripts to simplify setup, but at times it may be beneficial to have direct command-line access to `gulp` itself. You can install the `gulp` CLI using [these "getting started" instructions]((https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
+```
+npm start
+```
+
+### Using Gulp directly
+
+This project uses a locally-installed `gulp` with [`npm` scripts](https://docs.npmjs.com/misc/scripts) to simplify setup, but at times it may be useful to have direct command-line access to `gulp` itself. You can install the `gulp` CLI using [these "getting started" instructions]((https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
 
 This table shows the corresponding `gulp` commands for each `npm` command:
 
-Task | `npm` command | corresponding CLI command
+Task | `npm` command | `gulp` command
 ---- | ------------- | -------------------------
-Install NPM dependencies | `npm install` | _n/a_
 Compile SCSS to CSS | `npm run gulp:styles` | `gulp styles`
 Start Gulp watch task to auto-rebuild SCSS | `npm run gulp` | `gulp`
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,51 @@
+# Planet 4 Presentation Layer
 
+## Local Installation
 
-* Install bower globally using npm 
-`npm install -b bower`
+Execute these two `npm` commands to install project dependencies
 
-Install gulp also using this link https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md
+```
+npm install
+npm run bower
+```
 
-Once both are installed then run following commands to install dependencies
+To compile the SCSS source to CSS, use
 
-`npm install`
+```
+npm run gulp:styles
+```
 
-`bower install`
+To watch SCSS files and rebuild the CSS whenever a `.scss` source file changes, use
 
-To compile scss to css use
+```sh
+npm run gulp
+```
 
-`bower styles`
+This will automatically re-compile your CSS whenever a `.scss` source file changes, but you will still have to manually reload the browser tab to see the change. Auto reload is not present so far.
 
-To keep watching changes in .scss and compile them use
+### Using Bower & Gulp globally
 
-`bower`
+This project uses locally-installed build tools & `npm` scripts to simplify setup, but at times it may be beneficial to have full access to build tools like `gulp` or `bower`. If you wish to use these command-line utilities directly, you can install them globally:
 
-Once you make any change in scss file you will get compilation but then you have releod the browser and to see that change. Auto reload is not present so far.
+- To install the `bower` command line utility, run `npm install -g bower`.
+- To install the `gulp` command line utility, [follow these Gulp "getting started" instructions]((https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
 
-Coding buidelines are very important here in this project and delivery depends on that.
+### Command Reference
+
+This table shows the corresponding `bower` and `gulp` commands for each `npm` command.
+
+Task | `npm` command | corresponding CLI command
+---- | ------------- | -------------------------
+Install NPM dependencies | `npm install` | _n/a_
+Install Bower dependencies | `npm run bower` | `bower install`
+Compile SCSS to CSS | `npm run gulp:styles` | `gulp styles`
+Start Gulp watch task to auto-rebuild SCSS | `npm run gulp` | `gulp`
+
+## Coding Guidelines
+
+Coding guidelines are very important here in this project and delivery depends on that.
 
 * (CSS Coding practices)[https://make.wordpress.org/core/handbook/best-practices/coding-standards/css/]
 * (JS Coding practices)[https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/]
 * CSS Naming variables (1)[https://blog.toughbyte.com/blabla-9fd86eae4e6c] (2)[https://medium.com/@drublic/css-naming-conventions-less-rules-more-fun-12af220e949b]
 * Naming convention (1)[http://thesassway.com/advanced/modular-css-naming-conventions]
-
-

--- a/act.html
+++ b/act.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Act :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "planet4-master-theme",
-  "dependencies": {
-    "bootstrap": "4.0.0-alpha.6",
-    "font-awesome": "fontawesome#^4.7.0"
-  }
-}

--- a/explore.html
+++ b/explore.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Explore :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/happy-point-form.html
+++ b/happy-point-form.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Home :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/home.html
+++ b/home.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Home :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta charset="UTF-8" />
 	<title>Home :: Greenpeace 2017</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/issue.html
+++ b/issue.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Issue :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,6 +296,12 @@
         "hoek": "4.2.0"
       }
     },
+    "bower": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,12 +296,6 @@
         "hoek": "4.2.0"
       }
     },
-    "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -374,6 +374,20 @@
         "supports-color": "2.0.0"
       }
     },
+    "cli-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
+      "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "memoizee": "0.4.11",
+        "timers-ext": "0.1.2"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -652,10 +666,22 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "dev": true
+    },
     "deprecated": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-file": {
@@ -698,10 +724,22 @@
         "jsbn": "0.1.1"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.21",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz",
       "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "end-of-stream": {
@@ -789,10 +827,22 @@
         "es6-symbol": "3.1.1"
       }
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-emitter": {
@@ -903,6 +953,38 @@
         "repeat-string": "1.6.1"
       }
     },
+    "finalhandler": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
@@ -1004,6 +1086,12 @@
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -1275,6 +1363,12 @@
       "requires": {
         "natives": "1.1.0"
       }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -1609,6 +1703,18 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2308,6 +2414,12 @@
         "regex-cache": "0.4.4"
       }
     },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -2691,6 +2803,15 @@
         }
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
@@ -2699,6 +2820,12 @@
       "requires": {
         "wrappy": "1.0.2"
       }
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
     },
     "orchestrator": {
       "version": "0.3.8",
@@ -2784,6 +2911,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "path-exists": {
@@ -2970,6 +3103,12 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
+    "querystringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+      "dev": true
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -3010,6 +3149,12 @@
           }
         }
       }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -3070,6 +3215,34 @@
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
+      }
+    },
+    "reload": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/reload/-/reload-2.2.2.tgz",
+      "integrity": "sha512-su5O0Db0LSxAw4XHl7FeSlu79PYaFt+OFxEIdc2/kb+pechWOnlQxV2LB+kHVdjjghQ7/2J1G/AWH20qUAywQQ==",
+      "dev": true,
+      "requires": {
+        "cli-color": "1.2.0",
+        "commander": "2.9.0",
+        "finalhandler": "1.0.6",
+        "minimist": "1.2.0",
+        "open": "0.0.5",
+        "serve-static": "1.12.6",
+        "supervisor": "0.12.0",
+        "url-parse": "1.1.9",
+        "ws": "3.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        }
       }
     },
     "remove-trailing-separator": {
@@ -3145,6 +3318,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -3282,16 +3461,72 @@
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
     },
+    "send": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
+      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "sequencify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
     },
+    "serve-static": {
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
+      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.15.6"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
       "dev": true
     },
     "shell-quote": {
@@ -3408,6 +3643,12 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
@@ -3532,6 +3773,12 @@
       "requires": {
         "get-stdin": "4.0.1"
       }
+    },
+    "supervisor": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.12.0.tgz",
+      "integrity": "sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
@@ -3670,6 +3917,12 @@
       "integrity": "sha1-vqcr9JeerO8TowLPR7LRrz80QZc=",
       "dev": true
     },
+    "ultron": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "dev": true
+    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -3682,11 +3935,27 @@
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "dev": true,
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -3851,6 +4120,24 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
+      "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1",
+        "ultron": "1.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        }
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "gulp-sourcemaps": "^2.6.1",
     "gulp-uglify": "^3.0.0",
     "gulp-uglifycss": "^1.0.8",
+    "reload": "^2.2.2",
     "yarn-run-all": "^3.1.1"
   },
   "scripts": {
     "css": "postcss -o style.css src/css/style.css --map.annotation style.css.map --config .postcss.json -u autoprefixer -u postcss-partial-import -u postcss-custom-properties -u postcss-csso",
     "gulp": "gulp",
     "gulp:styles": "gulp styles",
+    "serve": "reload -b",
+    "start": "npm-run-all --parallel serve gulp",
     "build": "npm-run-all --parallel css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "normalize.css": "^7.0.0"
   },
   "devDependencies": {
-    "bower": "^1.8.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-concat": "^2.6.1",
@@ -22,7 +21,6 @@
     "yarn-run-all": "^3.1.1"
   },
   "scripts": {
-    "bower": "bower install",
     "css": "postcss -o style.css src/css/style.css --map.annotation style.css.map --config .postcss.json -u autoprefixer -u postcss-partial-import -u postcss-custom-properties -u postcss-csso",
     "gulp": "gulp",
     "gulp:styles": "gulp styles",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "normalize.css": "^7.0.0"
   },
   "devDependencies": {
+    "bower": "^1.8.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-concat": "^2.6.1",
@@ -21,7 +22,10 @@
     "yarn-run-all": "^3.1.1"
   },
   "scripts": {
+    "bower": "bower install",
     "css": "postcss -o style.css src/css/style.css --map.annotation style.css.map --config .postcss.json -u autoprefixer -u postcss-partial-import -u postcss-custom-properties -u postcss-csso",
+    "gulp": "gulp",
+    "gulp:styles": "gulp styles",
     "build": "npm-run-all --parallel css"
   }
 }

--- a/post.html
+++ b/post.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Post :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/search-result.html
+++ b/search-result.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Search Result :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />

--- a/search-without-result.html
+++ b/search-without-result.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Search Without Result :: Greenpeace 2017</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="shortcut icon" type="image/ico" href="favicon.ico" />


### PR DESCRIPTION
Since Bower did not appear to be in use, this PR removes it from the project, and wraps all necessary `gulp` commands in [`npm` scripts](https://docs.npmjs.com/misc/scripts) to permit the build commands to be used without any globally-installed packages.

This PR also adds an `npm start` command, which uses [`reload`](https://www.npmjs.com/package/reload) to start a live-reloading dev server (and runs `gulp` in parallel). Any HTML or SCSS changes will cause the page to be reloaded, speeding up development iteration.