### PR TITLE
Rationalise all font-size declarations

### DIFF
--- a/src/scss/common/_article.scss
+++ b/src/scss/common/_article.scss
@@ -134,7 +134,7 @@
   h3 {
     color: #152431;
     margin: 0 0 30px 0;
-    font-size: 2.375rem;
+    font-size: rem(38);
   }
   .topicwise-article-section {
     .topicwise-article-list {
@@ -145,14 +145,14 @@
         .topicwise-article-body {
           a.article-headline {
             color: #2B092C;
-            font-size: 2rem;
+            font-size: rem(32);
             font-weight: bold;
             text-decoration: none;
           }
           .topicwise-article-tags {
             color: #258CCB;
             .article-topic-title {
-              font-size: 1rem;
+              font-size: rem(16);
               font-weight: bold;
               margin-right: 5px;
               text-decoration: none;
@@ -191,7 +191,7 @@
         .topicwise-article-body {
           padding: 15px;
           h4.article-headline {
-            font-size: 1.25rem;
+            font-size: rem(20);
           }
           .topicwise-article-tags {
             padding-top: 10px;

--- a/src/scss/common/_author-block.scss
+++ b/src/scss/common/_author-block.scss
@@ -36,18 +36,18 @@
       @include skew($bg: #E2E5E8, $deg: 25deg, $right: -70px, $width: 155px);
       .author-info-inner {
         h2 {
-          font-size: 1.25rem;
+          font-size: rem(20);
           font-weight: bold;
           margin-bottom: 16px;
         }
         h5 {
-          font-size: 1.03125rem;
+          font-size: rem(16.5);
           font-weight: 500;
           color: #E51538;
           margin-bottom: 40px;
         }
         p {
-          font-size: 1.0625rem;
+          font-size: rem(17);
         }
       }
 
@@ -80,15 +80,15 @@
         @include skew($bg: #E2E5E8, $deg: 0deg, $right: 0px, $width: 0px);
         .author-info-inner {
           h2 {
-            font-size: 1rem;
+            font-size: rem(16);
             margin-bottom: 8px;
           }
           h5 {
-            font-size: 1.03125rem;
+            font-size: rem(16.5);
             margin-bottom: 40px;
           }
           p {
-            font-size: 1rem;
+            font-size: rem(16);
           }
         }
 
@@ -121,15 +121,15 @@
         @include skew($bg: #E2E5E8, $deg: 25deg, $right: -70px, $width: 155px);
         .author-info-inner {
           h2 {
-            font-size: 1rem;
+            font-size: rem(16);
             margin-bottom: 8px;
           }
           h5 {
-            font-size: 1.03125rem;
+            font-size: rem(16.5);
             margin-bottom: 40px;
           }
           p {
-            font-size: 1rem;
+            font-size: rem(16);
           }
         }
 
@@ -162,15 +162,15 @@
         @include skew($bg: #E2E5E8, $deg: 25deg, $right: -70px, $width: 155px);
         .author-info-inner {
           h2 {
-            font-size: 1rem;
+            font-size: rem(16);
             margin-bottom: 8px;
           }
           h5 {
-            font-size: 1.03125rem;
+            font-size: rem(16.5);
             margin-bottom: 40px;
           }
           p {
-            font-size: 1rem;
+            font-size: rem(16);
           }
         }
 

--- a/src/scss/common/_campaign-thumbnail-block.scss
+++ b/src/scss/common/_campaign-thumbnail-block.scss
@@ -32,7 +32,7 @@
 .campaign-thumbnail-block {
   margin-top: 72px;
   h2 {
-    font-size: 2rem;
+    font-size: rem(32);
     margin-bottom: 48px;
   }
   .thumbnail-largeview-container {
@@ -52,7 +52,7 @@
       }
       a {
         text-align: center;
-        font-size: 1.25rem;
+        font-size: rem(20);
         color: $yellow-button;
         font-weight: bold;
         position: absolute;

--- a/src/scss/common/_carousel-header.scss
+++ b/src/scss/common/_carousel-header.scss
@@ -102,7 +102,7 @@
         line-height: normal;
         }
         p {
-        font-size: 1.375rem;  
+        font-size: rem(22);
         margin-bottom: 72px;
         width: 70%;
         line-height: normal;
@@ -145,7 +145,7 @@
             font-weight: 500;
           }
           h3 {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 20px;
             font-weight: 300;  
           }
@@ -176,17 +176,17 @@
 //           padding-top: 40px;
 //           padding-bottom: 80px;
 //           h1 {
-//             font-size: 3rem;
+//             font-size: rem(48);
 //             margin-bottom: 40px;
 //             font-weight: 500;
 //           }
 //           h3 {
-//             font-size: 1.5rem;
+//             font-size: rem(24);
 //             margin-bottom: 50px;
 //             font-weight: 300;
 //           }
 //           p {
-//             font-size: 1.1875rem;
+//             font-size: rem(27.5);
 //             margin-bottom: 32px;
 //           }
 //         }
@@ -205,17 +205,17 @@
           padding-top: 40px;
           padding-bottom: 80px;
           h1 {
-            font-size: 3rem;
+            font-size: rem(48);
             margin-bottom: 40px;
             font-weight: 500;
           }
           h3 {
-            font-size: 1.5rem;
+            font-size: rem(24);
             margin-bottom: 50px;
             font-weight: 300;
           }
           p {
-            font-size: 1.1875rem;
+            font-size: rem(27.5);
             margin-bottom: 32px;
           }
         }
@@ -233,17 +233,17 @@
           padding-top: 100px;
           padding-bottom: 80px;
           h1 {
-            font-size: 3.5rem;
+            font-size: rem(56);
             font-weight: 500;
             margin-bottom: 50px;
           }
           h3 {
-            font-size: 1.875rem;
+            font-size: rem(30);
             font-weight: 300;
             margin-bottom: 50px;
           }
           p {
-            font-size: 1.25rem;
+            font-size: rem(20);
             margin-bottom: 32px;
           }
         }

--- a/src/scss/common/_carousel.scss
+++ b/src/scss/common/_carousel.scss
@@ -56,7 +56,7 @@
 .carousel-wrap {
     padding-top: 100px;
       h1 {
-        font-size: 2.375rem;
+        font-size: rem(38);
         color: #152431;
         margin-bottom: 40px; 
       }
@@ -66,7 +66,7 @@
           right: 0;
           top: 0;
           color: $white;
-          font-size: 0.875rem;
+          font-size: rem(14);
           margin: 15px;
           font-weight: normal;
         }
@@ -149,7 +149,7 @@
       padding-top: 70px;
       padding-bottom: 70px;
         h1 {
-          font-size:  2.125rem;
+          font-size: rem(34);
           margin-left: 0px;
           margin-bottom: 40px;
         }
@@ -171,10 +171,10 @@
         width: 100%;
         height: 195px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         }
         .carousel-control-prev,
@@ -191,7 +191,7 @@
       padding-top: 70px;
       padding-bottom: 70px;
         h1 {
-          font-size:  2.125rem;
+          font-size: rem(34);
           margin-left: 0px;
           margin-bottom: 40px;
         }
@@ -201,10 +201,10 @@
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         } 
       }  
@@ -214,17 +214,17 @@
   @media (min-width: 992px) {
     .carousel-wrap {
         h1 {
-          font-size:  2.125rem;
+          font-size: rem(34);
           margin-left: 0px;
           margin-bottom: 40px;
         }
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         } 
       }  
@@ -236,17 +236,17 @@
       padding-top: 104px;
       padding-bottom: 104px;
         h1 {
-          font-size:  2.125rem;
+          font-size: rem(34);
           margin-left: 0px;
           margin-bottom: 40px;
         }
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         } 
       }  

--- a/src/scss/common/_comments-block.scss
+++ b/src/scss/common/_comments-block.scss
@@ -62,7 +62,7 @@
 .comments-block {
   padding-top: 104px;
   h2 {
-    font-size: 2.5rem;
+    font-size: rem(40);
     margin-bottom: 56px;
   }
   .comments-block-inner {
@@ -72,19 +72,19 @@
     .form-section {
       form {
         h3 {
-          font-size: 1.375rem;
+          font-size: rem(22);
           margin-bottom: 56px;
         }
         .form-group {
           margin-bottom: 32px;
           label {
-            font-size: 1.125rem;
+            font-size: rem(18);
             font-weight: 500;
           }
           textarea {
             border:none;
             background: #D9D9D9;
-            font-size: 1.375rem;
+            font-size: rem(22);
             border-radius: 0;
             margin-bottom: 56px;
           }
@@ -96,7 +96,7 @@
             background: transparent;
             border-radius: 0;
             padding: 0;
-            font-size: 1.375rem;
+            font-size: rem(22);
             font-weight: normal;
             width: 50%;
           }
@@ -131,19 +131,19 @@
       .single-comment {
         margin-bottom: 64px;
         h3.comment-heading {
-          font-size: 1.375rem;
+          font-size: rem(22);
           margin-bottom: 40px;
           font-weight: bold;
           color: #3C3C3B;
         }
         p.comment-text {
-          font-size: 1.125rem;
+          font-size: rem(18);
           font-family: roboto;
           margin-bottom: 32px;
           color: #706F6F;
         }
         a {
-          font-size: 1.125rem;
+          font-size: rem(18);
           font-weight: 500;
           color: $black;
           text-decoration: none;
@@ -168,7 +168,7 @@
   .comments-block {
     padding-top: 64px;
     h2 {
-      font-size: 2rem;
+      font-size: rem(32);
       margin-bottom: 40px;
     }
     .comments-block-inner {
@@ -176,19 +176,19 @@
       .form-section {
         form {
           h3 {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           .form-group {
             margin-bottom: 32px;
             label {
-              font-size: 1.125rem;
+              font-size: rem(18);
             }
             textarea {
               margin-bottom: 40px;
             }
             input {
-              font-size: 1.375rem;
+              font-size: rem(22);
               width: 100%;
             }
           }
@@ -212,15 +212,15 @@
         .single-comment {
           margin-bottom: 64px;
           h3.comment-heading {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           p.comment-text {
-            font-size: 1.125rem;
+            font-size: rem(18);
             margin-bottom: 32px;
           }
           a {
-            font-size: 1.125rem;
+            font-size: rem(18);
             &.author-info {
             }
             &.comment-date {
@@ -237,7 +237,7 @@
   .comments-block {
     padding-top: 64px;
     h2 {
-      font-size: 2rem;
+      font-size: rem(32);
       margin-bottom: 40px;
     }
     .comments-block-inner {
@@ -245,19 +245,19 @@
       .form-section {
         form {
           h3 {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           .form-group {
             margin-bottom: 32px;
             label {
-              font-size: 1.125rem;
+              font-size: rem(18);
             }
             textarea {
               margin-bottom: 40px;
             }
             input {
-              font-size: 1.375rem;
+              font-size: rem(22);
               width: 80%;
             }
           }
@@ -281,15 +281,15 @@
         .single-comment {
           margin-bottom: 64px;
           h3.comment-heading {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           p.comment-text {
-            font-size: 1.125rem;
+            font-size: rem(18);
             margin-bottom: 32px;
           }
           a {
-            font-size: 1.125rem;
+            font-size: rem(18);
             &.author-info {
             }
             &.comment-date {
@@ -306,7 +306,7 @@
   .comments-block {
     padding-top: 104px;
     h2 {
-      font-size: 2.5rem;
+      font-size: rem(40);
       margin-bottom: 56px;
     }
     .comments-block-inner {
@@ -314,19 +314,19 @@
       .form-section {
         form {
           h3 {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 56px;
           }
           .form-group {
             margin-bottom: 32px;
             label {
-              font-size: 1.125rem;
+              font-size: rem(18);
             }
             textarea {
               margin-bottom: 40px;
             }
             input {
-              font-size: 1.375rem;
+              font-size: rem(22);
               width: 50%;
             }
           }
@@ -350,15 +350,15 @@
         .single-comment {
           margin-bottom: 64px;
           h3.comment-heading {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           p.comment-text {
-            font-size: 1.125rem;
+            font-size: rem(18);
             margin-bottom: 32px;
           }
           a {
-            font-size: 1.125rem;
+            font-size: rem(18);
             &.author-info {
             }
             &.comment-date {
@@ -375,7 +375,7 @@
   .comments-block {
     padding-top: 64px;
     h2 {
-      font-size: 2.5rem;
+      font-size: rem(40);
       margin-bottom: 56px;
     }
     .comments-block-inner {
@@ -383,19 +383,19 @@
       .form-section {
         form {
           h3 {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           .form-group {
             margin-bottom: 32px;
             label {
-              font-size: 1.125rem;
+              font-size: rem(18);
             }
             textarea {
               margin-bottom: 40px;
             }
             input {
-              font-size: 1.375rem;
+              font-size: rem(22);
               width: 50%;
             }
           }
@@ -419,15 +419,15 @@
         .single-comment {
           margin-bottom: 64px;
           h3.comment-heading {
-            font-size: 1.375rem;
+            font-size: rem(22);
             margin-bottom: 40px;
           }
           p.comment-text {
-            font-size: 1.125rem;
+            font-size: rem(18);
             margin-bottom: 32px;
           }
           a {
-            font-size: 1.125rem;
+            font-size: rem(18);
             &.author-info {
             }
             &.comment-date {

--- a/src/scss/common/_content-four-column.scss
+++ b/src/scss/common/_content-four-column.scss
@@ -88,7 +88,7 @@
   color: #200721;
   padding: 104px 0 0 0;
   h2 {
-    font-size: 2.5rem;
+    font-size: rem(40);
     margin: 0;
 
   }
@@ -119,11 +119,11 @@
         margin: 0;
       }
       p {
-        font-size: 1rem; 
+        font-size: rem(16);
         line-height: 1.875rem;
         font-family: roboto;
         &.publication-date {
-          font-size: 0.9rem; 
+          font-size: rem(14.5);
           font-style: italic;
           margin-bottom: 20px;
           color: #868e96;
@@ -131,7 +131,7 @@
       } 
       a {
         color: $blue-text;
-        font-size: 14px;
+        font-size: rem(14);
         opacity: 0.75;
         text-decoration: underline; 
       }
@@ -149,7 +149,7 @@
 @media (max-width: 575px) {
   .four-coloum-content {
     h2 {
-      font-size: 2.25rem;
+      font-size: rem(36);
     }
     .four-coloum-content-info {
       h4 {
@@ -170,7 +170,7 @@
 @media (min-width: 768px) {
   .four-coloum-content {
     h2 {
-      font-size: 2.25rem;
+      font-size: rem(36);
     }
     .four-coloum-content-info {
       h4 {

--- a/src/scss/common/_content-three-column.scss
+++ b/src/scss/common/_content-three-column.scss
@@ -36,12 +36,12 @@
   .three-column-box { 
     .three-column-info { 
        h2 { 
-         font-size: 2.5rem; 
+         font-size: rem(40);
          margin-bottom: 64px; 
          font-weight: bold;
        } 
        p { 
-         font-size: 1.375rem; 
+         font-size: rem(22);
          line-height: 2.25rem; 
          margin-bottom: 0px; 
        } 
@@ -92,11 +92,11 @@
     .three-column-box { 
       .three-column-info { 
          h2 { 
-           font-size: 1.625rem; 
+           font-size: rem(26);
            margin-bottom: 32px; 
          } 
          p { 
-           font-size: 1.0625rem; 
+           font-size: rem(17);
            line-height: 1.25rem; 
            margin-bottom: 40px; 
          } 
@@ -153,11 +153,11 @@
     .three-column-box { 
       .three-column-info { 
          h2 { 
-           font-size: 2.1875rem; 
+           font-size: rem(35);
            margin-bottom: 64px; 
          } 
          p { 
-           font-size: 1.1875rem; 
+           font-size: rem(27.5);
            line-height: 2.25rem; 
            margin-bottom: 40px; 
            &:last-child {
@@ -217,11 +217,11 @@
     .three-column-box { 
       .three-column-info { 
          h2 { 
-           font-size: 2.5rem; 
+           font-size: rem(40);
            margin-bottom: 64px; 
          } 
          p { 
-           font-size: 1.375rem; 
+           font-size: rem(22);
            line-height: 2.25rem; 
            margin-bottom: 0px; 
            &:last-child {
@@ -281,11 +281,11 @@
     .three-column-box { 
       .three-column-info { 
          h2 { 
-           font-size: 2.5rem; 
+           font-size: rem(40);
            margin-bottom: 64px; 
          } 
          p { 
-           font-size: 1.375rem; 
+           font-size: rem(22);
            line-height: 2.25rem; 
            margin-bottom: 0px; 
          } 

--- a/src/scss/common/_covers.scss
+++ b/src/scss/common/_covers.scss
@@ -87,12 +87,12 @@
      color: $white;
     }
     h2 {
-     font-size: 1.75rem;
+     font-size: rem(28);
      margin-bottom: 32px;
      position: relative;
     }
     p {
-     font-size: 1.25rem;
+     font-size: rem(20);
      line-height: 2rem;
      color: $white;
      position: relative;

--- a/src/scss/common/_footer.scss
+++ b/src/scss/common/_footer.scss
@@ -13,7 +13,7 @@
       display: inline-block;
       margin: 0 10px;
       i {
-        font-size: 30px;
+        font-size: rem(30);
         color: $white;
       }
     }
@@ -22,7 +22,7 @@
     text-align: center;
     li {
       display: inline-block;
-      font-size: 22px;
+      font-size: rem(22);
       color: $white;
       margin-bottom: 32px;
       a {
@@ -74,7 +74,7 @@
     color: $white;
     margin-bottom: 0;
     &.copyright-text {
-      font-size: 11px;
+      font-size: rem(11);
       color: $white;
       margin: 20px 0;
       text-align: center;

--- a/src/scss/common/_happy-point-block.scss
+++ b/src/scss/common/_happy-point-block.scss
@@ -49,7 +49,7 @@
     @include background-before-opacity(#D6E6F2);
     p {
       font-family: roboto;
-      font-size: 0.8rem;
+      font-size: rem(13);
       line-height: 1rem;
       color: #868e96;
     }
@@ -73,12 +73,12 @@
       padding-right: 0;
     }
     h2 {
-      font-size: 1.625rem;
+      font-size: rem(26);
       line-height: 2rem;
       margin-bottom: 24px;
     }
     h5 {
-      font-size: 1rem;
+      font-size: rem(16);
       line-height: 1.5rem;
     }
     .subscriber-btn {
@@ -107,12 +107,12 @@
       padding-right: 0;
     }
     h2 {
-      font-size: 1.75rem;
+      font-size: rem(28);
       line-height: 2.125rem;
       margin-bottom: 8px;
     }
     h5 {
-      font-size: 1.125rem;
+      font-size: rem(18);
       line-height: 1.75rem;
     }
     .subscriber-btn {
@@ -135,12 +135,12 @@
       padding-right: 0;
     }
     h2 {
-      font-size: 2.125rem;
+      font-size: rem(34);
       line-height: 2.125rem;
       margin-bottom: 24px;
     }
     h5 {
-      font-size: 1.125rem;
+      font-size: rem(18);
       line-height: 1.5rem;
     }
     .subscriber-btn {
@@ -163,10 +163,10 @@
       padding-top: 350px;
     }
     h2 {
-      font-size: 2.25rem;
+      font-size: rem(36);
     }
     h5 {
-      font-size: 1.125rem;
+      font-size: rem(18);
     }
     .subscriber-btn {
       margin-top: 0px;

--- a/src/scss/common/_header.scss
+++ b/src/scss/common/_header.scss
@@ -25,15 +25,15 @@
   padding-top: 120px;
   padding-bottom: 70px;
   h1{
-    font-size: 4rem;
+    font-size: rem(64);
     margin-bottom: 48px;
   }
   h3{
-    font-size: 2.75rem;
+    font-size: rem(44);
     margin-bottom: 56px;
   }
   p{
-    font-size: 1.375rem;  
+    font-size: rem(22);
     margin-bottom: 72px;
   }
 
@@ -47,11 +47,11 @@
     padding-top: 120px;
     padding-bottom: 80px;
 	    h1{
-	      font-size: 2.5rem;
+	      font-size: rem(40);
 	      margin-bottom: 50px;
 	    }
 	    h3{
-	      font-size: 1.375rem;
+	      font-size: rem(22);
 	      margin-bottom: 130px;
 	    }
 	    p{
@@ -66,15 +66,15 @@
   	padding-top: 80px;
     padding-bottom: 80px;
 	    h1{
-	      font-size: 3rem;
+	      font-size: rem(48);
 	      margin-bottom: 40px;
 	    }
 	    h3{
-	      font-size: 1.5rem;
+	      font-size: rem(24);
 	      margin-bottom: 50px;
 	    }
 	    p{
-	      font-size: 1.1875rem;
+	      font-size: rem(27.5);
 	    }
 	}   
 }
@@ -85,15 +85,15 @@
     padding-top: 100px;
     padding-bottom: 80px;
 	    h1{
-	      font-size: 3.5rem;
+	      font-size: rem(56);
 	      margin-bottom: 50px;
 	    }
 	    h3{
-	      font-size: 1.875rem;
+	      font-size: rem(30);
 	      margin-bottom: 50px;
 	    }
 	    p{
-	      font-size: 1.25rem;
+	      font-size: rem(20);
 	    }
 
   	}

--- a/src/scss/common/_navbar.scss
+++ b/src/scss/common/_navbar.scss
@@ -125,11 +125,11 @@
         }   
         a {
           color: $white;
-          font-size: 16px;
+          font-size: rem(16);
           display: inline-block; 
         }
         .btn-secondary {
-          font-size: 12px;
+          font-size: rem(12);
           color: $black;
           margin-top: 3px;
         }
@@ -142,12 +142,12 @@
           i {
             display: inline-block;
             float: left;
-            font-size: 30px;
+            font-size: rem(30);
             margin-top: 5px;
           }
           a {
             color: $nav-link;
-            font-size: 16px;
+            font-size: rem(16);
             margin: 9px 2px 0;
             &:hover {
               transition: 0.5s;
@@ -195,7 +195,7 @@
           margin-left: 10px;
         }
         .selected-option {
-          font-size: 0.9rem;
+          font-size: rem(14.5);
           color: $white;
           line-height: 40px;
           display: block;
@@ -229,7 +229,7 @@
           .country-option-box {
             color: $white;
             text-align: left;
-            font-size: 0.9rem;
+            font-size: rem(14.5);
             line-height: 24px;
             width: 100%;
             .default-lang {
@@ -369,7 +369,7 @@
   //     padding: 10px 20px;
   //     background: #F2A781;
   //     color: $white;
-  //     font-size: 14px;
+  //     font-size: rem(14);
   //     text-transform: uppercase;
   //   }
   //   .navbar-nav {
@@ -391,7 +391,7 @@
   //     border: 0;
   //     outline: none;
   //     padding: 0;
-  //     font-size: 14px;
+  //     font-size: rem(14);
   //     font-weight: bold;
   //     color: #676767;
   //   }
@@ -404,7 +404,7 @@
   //     border: 0;
   //     outline: none;
   //     cursor: pointer;
-  //     font-size: 15px;
+  //     font-size: rem(15);
   //   }
   //   #searchbar {
   //     display: none;
@@ -492,7 +492,7 @@
       border: 0;
       outline: none;
       padding: 0;
-      font-size: 14px;
+      font-size: rem(14);
       font-weight: bold;
       color: #676767;
     }
@@ -504,7 +504,7 @@
       border: 0;
       outline: none;
       cursor: pointer;
-      font-size: 15px;
+      font-size: rem(15);
     }
     #searchbar {
       display: none;
@@ -530,7 +530,7 @@
       li {
         width: 35%;
         a {
-          font-size: 18px;
+          font-size: rem(18);
         }
         &.big-screen-nav-link {
           margin-top: 12px;

--- a/src/scss/common/_search-block.scss
+++ b/src/scss/common/_search-block.scss
@@ -1489,7 +1489,7 @@
               .action-btn {
                 margin-top: 10px;
                 i {             
-                  font-size: 1rem;
+                  font-size: rem(16);
                   font-weight: bold;
                   margin-right: 10px;
                   float: left;

--- a/src/scss/common/_split-carousel.scss
+++ b/src/scss/common/_split-carousel.scss
@@ -67,7 +67,7 @@
           right: 0;
           top: 0;
           color: $white;
-          font-size: 0.875rem;
+          font-size: rem(14);
           margin: 15px 130px;
           font-weight: normal;
         }
@@ -190,7 +190,7 @@
   .split-carousel-wrap {
     overflow: hidden;
       h1 {
-        font-size:  rem(26);
+        font-size: rem(26);
         margin-left: 0px;
         margin-bottom: 40px;
         line-height: 30px;
@@ -208,7 +208,7 @@
           font-size: rem(17);
         }
         p {
-          font-size: 0.8125rem;
+          font-size: rem(13);
         }
       }
       .carousel-control-prev,
@@ -259,7 +259,7 @@
       // padding-top: 70px;
       // padding-bottom: 70px;
         h1 {
-          font-size:  rem(34);
+          font-size: rem(34);
           margin-left: 0px;
           margin-bottom: 40px;
           line-height: 40px;
@@ -270,10 +270,10 @@
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         }
         &.not-header {
@@ -318,7 +318,7 @@
     .split-carousel-wrap {
       overflow: hidden;
         h1 {
-          font-size:  rem(36);
+          font-size: rem(36);
           margin-left: 0px;
           margin-bottom: 40px;
           line-height: 42px;
@@ -326,10 +326,10 @@
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         } 
           &.not-header {
@@ -376,17 +376,17 @@
       // padding-top: 104px;
       // padding-bottom: 104px;
         h1 {
-          font-size:  rem(38);
+          font-size: rem(38);
           margin-left: 0px;
           margin-bottom: 40px;
         }
         .carousel-caption {
           padding: 20px 30px;
           h3 {
-            font-size: 1.0625rem;
+            font-size: rem(17);
           }
           p {
-            font-size: 0.8125rem;
+            font-size: rem(13);
           }
         }
         &.not-header {

--- a/src/scss/common/_split-two-column.scss
+++ b/src/scss/common/_split-two-column.scss
@@ -87,17 +87,17 @@
       right: 0;
       margin: 92px 0 0 166px;
       h2 {
-        font-size: 4.125rem;
+        font-size: rem(66);
         margin-bottom: 54px;
       }
       h5 {
-        font-size: 1.375rem;
+        font-size: rem(22);
         line-height: 2.2rem;
         font-weight: normal;
         margin-bottom: 48px;
       }
       a {
-        font-size: 1.375rem;
+        font-size: rem(22);
         color: $yellow-button;
         text-decoration: underline;
         font-weight: bold;
@@ -123,7 +123,7 @@
       }
       a {
         color: $brown-bg-tags-text;
-        font-size: 2.375rem;
+        font-size: rem(38);
         font-weight: bold;
         text-decoration: none;
         margin-bottom: 20px;
@@ -148,7 +148,7 @@
           @include background('images/GP04JE6.jpg');
         }
         a {
-          font-size: 2.25rem;
+          font-size: rem(36);
           display: block;
           padding: 25px 15px;  
           color: $white;
@@ -179,16 +179,16 @@
         width: 51%;
         margin: 64px -8px 0 0px;
         h2 {
-          font-size: 3rem;
+          font-size: rem(48);
           margin-bottom: 72px;
         }
         h5 {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
           margin-bottom: 10px;
         }
         a {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
         }
       }
@@ -203,12 +203,12 @@
         margin-left: 120px;
         margin-top: 185px;
         h5 {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
           margin-bottom: 10px;
         }
         a {
-          font-size: 1.75rem;
+          font-size: rem(28);
           margin-bottom: 40px;
         }
       }
@@ -225,16 +225,16 @@
         width: 40%;
         margin: 72px 73px 0 0px;
         h2 {
-          font-size: 3.5rem;
+          font-size: rem(56);
           margin-bottom: 72px;
         }
         h5 {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
           margin-bottom: 0px;
         }
         a {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
         }
       }
@@ -249,12 +249,12 @@
         margin-left: 140px;
         margin-top: 135px;
         h5 {
-          font-size: 1.125rem;
+          font-size: rem(18);
           line-height: 2rem;
           margin-bottom: 10px;
         }
         a {
-          font-size: 2.5rem;
+          font-size: rem(40);
           margin-bottom: 20px;
         }
       }
@@ -270,16 +270,16 @@
       .part-left{
         margin: 92px 0 0 166px;
         h2 {
-          font-size: 4.125rem;
+          font-size: rem(66);
           margin-bottom: 54px;
         }
         h5 {
-          font-size: 1.375rem;
+          font-size: rem(22);
           line-height: 2.2rem;
           margin-bottom: 48px;
         }
         a {
-          font-size: 1.375rem;
+          font-size: rem(22);
           line-height: 2.2rem;
         }
       }
@@ -293,12 +293,12 @@
         margin-left: 160px;
         margin-top: 215px;
         h5 {
-          font-size: 1.375rem;
+          font-size: rem(22);
           line-height: 2.2rem;
           margin-bottom: 40px;
         }
         a {
-          font-size: 2.375rem;
+          font-size: rem(38);
           margin-bottom: 20px;
         }
       }

--- a/src/scss/common/_static-four-column.scss
+++ b/src/scss/common/_static-four-column.scss
@@ -115,7 +115,7 @@
   .four-coloum {
     h2{
       text-align: center; 
-      font-size: 1.8rem;
+      font-size: rem(29);
       }
       .four-coloum-wrap{
         .four-coloum-symbol{

--- a/src/scss/common/_subheader.scss
+++ b/src/scss/common/_subheader.scss
@@ -16,11 +16,11 @@
 	.subheader {
 		padding: 48px 0 32px 0; 
 		h2 {
-			font-size: 1.625rem;
+			font-size: rem(26);
 			margin-bottom: 32px;
 		}
 		p {
-			font-size: 1rem;
+			font-size: rem(16);
 			line-height: 1.5rem;
 		}
 	}
@@ -31,11 +31,11 @@
 	.subheader {
 		padding: 72px 0 48px 0; 
 		h2 {
-			font-size: 2.125rem;
+			font-size: rem(34);
 			margin-bottom: 24px;
 		}
 		p {
-			font-size: 1.25rem;
+			font-size: rem(20);
 			line-height: 1.625rem;
 		}
 	}
@@ -46,11 +46,11 @@
 	.subheader {
 		padding: 104px 0 40px 0; 
 		h2 {
-			font-size: 2.25rem;
+			font-size: rem(36);
 			margin-bottom: 40px;
 		}
 		p {
-			font-size: 1.25rem;
+			font-size: rem(20);
 			line-height: 1.625rem;
 		}
 	}
@@ -61,11 +61,11 @@
   	.subheader {
 		padding: 104px 0 72px 0; 
 		h2 {
-			font-size: 2.375rem;
+			font-size: rem(38);
 			margin-bottom: 40px;
 		}
 		p {
-			font-size: 1.375rem;
+			font-size: rem(22);
 			line-height: 1.625rem;
 		}
 	}

--- a/src/scss/common/_tag-cloud.scss
+++ b/src/scss/common/_tag-cloud.scss
@@ -29,7 +29,7 @@
   .tag-cloud-title {
     h2 {
       color: #200721;
-      font-size: 2rem;
+      font-size: rem(32);
     }
     .tag-cloud-list {
       a {
@@ -37,16 +37,16 @@
         text-decoration: none;
         margin-right: 5px;
         &.tag-xsmall {
-          font-size: 0.75rem;
+          font-size: rem(12);
         }
         &.tag-small {
-          font-size: 1rem;
+          font-size: rem(16);
         }
         &.tag-mid {
-          font-size: 1.5rem;
+          font-size: rem(24);
         }
         &.tag-big {
-          font-size: 1.75rem;
+          font-size: rem(28);
         }
       }
     }

--- a/src/scss/common/_video-block.scss
+++ b/src/scss/common/_video-block.scss
@@ -19,7 +19,7 @@
 .video-block {
   padding-top: 104px;
   h1 {
-    font-size: 2.5rem;
+    font-size: rem(40);
     margin-bottom: 64px;
   }
 }
@@ -30,7 +30,7 @@
   .video-block {
     padding-top: 72px;
     h1 {
-      font-size: 1.625rem;
+      font-size: rem(26);
       margin-bottom: 40px;
     }
     .video-section {
@@ -45,7 +45,7 @@
   .video-block {
     padding-top: 104px;
     h1 {
-      font-size: 2.125rem;
+      font-size: rem(34);
       margin-bottom: 48px;
     }
     .video-section {
@@ -60,7 +60,7 @@
   .video-block {
     padding-top: 88px;
     h1 {
-      font-size: 2.125rem;
+      font-size: rem(34);
       margin-bottom: 48px;
     }
     .video-section {
@@ -75,7 +75,7 @@
   .video-block {
     padding-top: 104px;
     h1 {
-      font-size: 2.5rem;
+      font-size: rem(40);
       margin-bottom: 64px;
     }
     .video-section {

--- a/src/scss/modules/_buttons.scss
+++ b/src/scss/modules/_buttons.scss
@@ -12,7 +12,7 @@ Stylesheet: Button Styles
   text-decoration: none;
   color: $white;
   font-size: 0.9em;
-  font-size: 34px;
+  font-size: rem(34);
   line-height: 34px;
   font-weight: normal;
   padding: 0 24px;
@@ -107,7 +107,7 @@ Stylesheet: Button Styles
   select {
     background: transparent;
     padding: 5px;
-    font-size: 16px;
+    font-size: rem(16);
     color: $white;
     line-height: 1;
     border: 0;
@@ -183,7 +183,7 @@ Stylesheet: Button Styles
   .btn {
     padding: 0 15px;
     &.btn-small {
-      font-size: 14px;
+      font-size: rem(14);
       height: 40px;
       line-height: 40px;
     }
@@ -195,7 +195,7 @@ Stylesheet: Button Styles
   .btn {
     padding: 0 15px;
     &.btn-medium {
-      font-size: 16px;
+      font-size: rem(16);
       height: 48px;
       line-height: 48px;
     }
@@ -212,7 +212,7 @@ Stylesheet: Button Styles
   .btn {
     padding: 0 15px;
     &.btn-medium {
-      font-size: 16px;
+      font-size: rem(16);
       height: 48px;
       line-height: 48px;
     }
@@ -229,7 +229,7 @@ Stylesheet: Button Styles
   .btn {
     padding: 0 15px;
     &.btn-medium {
-      font-size: 18px;
+      font-size: rem(18);
       height: 56px;
       line-height: 56px;
     }


### PR DESCRIPTION
Rationalising all font-size declarations as there were some using the `rem()` function, some using typed `rem`s, and even worse some using `px` declarations. This ensures that all font-sizes are using the same entry point which is easy to predict & use and will also allow easy modification via the function to support fall-back px sizes if needed.