### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# TODO: Consider switching this default rule to tabs for parity with planet4-master-theme
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.htaccess]
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = tab
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space


### PR DESCRIPTION
If your editor or IDE supports an editorconfig plugin, this file will allow that plugin to consistently apply basic whitespace rules as you edit code.

(VSCode, Sublime, Atom, PHP/WebStorm, etc all have editorconfig support, whether through plugins, extensions, or configuration)

Note that the [planet4-master-theme `.editorconfig`](https://github.com/greenpeace/planet4-master-theme/blob/master/.editorconfig) uses tabs as the default rule, not spaces; this is more in line with the WP coding standards, however this repository currently uses spaces consistently throughout. In order to avoid conflicts with ongoing development, spaces are used as the default in this PR; I will open an issue to revisit this and consider switching to tabs later on once this repository is not under such active development.