### PR TITLE
Prevent Gulp from Dying on the First Error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,12 @@ gulp.task('styles', function () {
       // outputStyle: 'nested',
       // outputStyle: 'expanded',
       precision: 10
-    } ) )
+    } ).on( 'error', function ( error ) {
+			notify.onError( {
+				title: 'Error linting scripts! 😱',
+				message: error.message,
+			} )( error );
+		} ) )
     .pipe( sourcemaps.write( { includeContent: false } ) )
     .pipe( sourcemaps.init( { loadMaps: true } ) )
     .pipe( autoprefixer() )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ gulp.task('styles', function () {
       precision: 10
     } ).on( 'error', function ( error ) {
 			notify.onError( {
-				title: 'Error linting scripts! 😱',
+				title: 'Error linting SCSS! 😱',
 				message: error.message,
 			} )( error );
 		} ) )


### PR DESCRIPTION
Gulp seems to die quite frequently - on the first parsing error it encounters and without throwing a global notice so it's not always easy to know that it's died.This adds error reporting that will alert a developer to the issue, but not kill gulp completely.