### PR TITLE
Account for the WP Admin Bar

### DIFF
--- a/src/scss/common/_navbar.scss
+++ b/src/scss/common/_navbar.scss
@@ -89,6 +89,15 @@
     width: 100%;
     z-index: 500;
     opacity: 0.8;
+
+    .admin-bar & {
+      top: 46px;
+
+      @media screen and (min-width: 783px) {
+        top: 32px;
+      }
+    }
+
     .navbar-brand {
       margin: 0;
     }

--- a/src/scss/partials/_hacks.scss
+++ b/src/scss/partials/_hacks.scss
@@ -1,0 +1,12 @@
+/**
+ * Hacks file for modifying and overriding external styles.
+ */
+
+/**
+ * Keep the admin bar fixed on mobile screens for consistency.
+ */
+@media screen and (max-width: 600px) {
+	#wpadminbar {
+		position: fixed;
+	}
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,9 +1,16 @@
-// Include the buttons
+/**
+ * Overrides and hacks.
+ */
+@import "partials/custom";
+@import "partials/hacks";
+
+/**
+ * Setup global styles
+ */
 @import "partials/variables";
 @import "partials/functions";
 @import "partials/mixins";
 @import "partials/typography";
-@import "partials/custom";
 @import "partials/font-icon";
 @import "modules/buttons";
 


### PR DESCRIPTION
Push the navbar down when the WP admin bar is displayed.

Resolves #75 
