### PR TITLE
Fix for font issue on post page

### DIFF
--- a/src/scss/pages/post/_article-content.scss
+++ b/src/scss/pages/post/_article-content.scss
@@ -1,6 +1,19 @@
 .post-content {
   color: $grey-80;
 
+  ul, ol {
+    font-family: $lora;
+    // Assumptions made for the font-size that it's behaviour is same
+    // as the p tags in the content
+    @include small-and-up {
+      font-size: rem(19);
+    }
+    
+    @include medium-and-up {
+      font-size: rem(20);
+    }
+  }
+    
   p {
     line-height: 1.8;
     margin: 15px 0;


### PR DESCRIPTION
Font family and font size were missing from the lists in posts page

Assumptions made for the font-size that it's behaviour is same as the `p` tags in the content.

Fixes 69 in the sheet, we are still discussing about the page-header heading width so that's needs to be taken care of in another PR. 