### PR TITLE
Hide tags dot on mobile

### DIFF
--- a/src/scss/common/_tags-list.scss
+++ b/src/scss/common/_tags-list.scss
@@ -32,5 +32,9 @@
 		display: inline-block;
 		position: absolute;
 		right: -15px;
+
+    @include mobile-only {
+      display: none;
+    }
 	}
 }


### PR DESCRIPTION
Since we stack the post tags bellow page type on mobile, we don't need to show that dot at all.