### PR TITLE
Fix search results heading

### DIFF
--- a/src/scss/pages/search/_search.scss
+++ b/src/scss/pages/search/_search.scss
@@ -1,70 +1,72 @@
 .search {
-	@include linear-gradient(to bottom, transparentize($green-20, .15) 0%, transparentize($grey-10, .5) 100%);
+  @include linear-gradient(to bottom, transparentize($green-20, .15) 0%, transparentize($grey-10, .5) 100%);
 }
 
 .search-block {
-	padding-top: 56px;
+  padding-top: 56px;
 
-	@include small-and-up {
-		padding-top: 64px;
-	}
+  @include small-and-up {
+    padding-top: 64px;
+  }
 }
 
 .result-statement {
-	font-size: rem(28);
-	margin-bottom: 8px;
+  font-size: rem(28);
+  margin-bottom: 8px;
+  line-height: 1.2;
 
-	@include small-and-up {
-		font-size: rem(48);
-	}
+  @include small-and-up {
+    font-size: rem(48);
+  }
 
-	@include large-and-up {
-		font-size: rem(56);
-	}
+  @include large-and-up {
+    font-size: rem(56);
+  }
 
-	@include x-large-and-up {
-		font-size: rem(66);
-	}
+  @include x-large-and-up {
+    font-size: rem(66);
+  }
 }
 
-.without-search-result {
-	margin-top: 48px;
+.without-search-result,
+.search-result {
+  margin-top: 48px;
 
-	@include small-and-up {
-		margin-top: 0;
-	}
+  @include small-and-up {
+    margin-top: 0;
+  }
 
-	@include large-and-up {
-		margin-top: 94px;
-	}
+  @include large-and-up {
+    margin-top: 94px;
+  }
 
-	@include x-large-and-up {
-		margin-top: 120px;
-	}
+  @include x-large-and-up {
+    margin-top: 120px;
+  }
 
-	.search-help-info {
-		font-size: rem(16);
-		margin-bottom: 24px;
-		padding-left: 20px;
-		font-family: $lora;
-		color: $grey-60;
-		line-height: 1.8;
+  .search-help-info {
+    font-size: rem(16);
+    margin-bottom: 24px;
+    padding-left: 20px;
+    font-family: $lora;
+    color: $grey-60;
+    line-height: 1.8;
 
-		@include small-and-up {
-			font-size: rem(18);
-			margin-bottom: 32px;
-			padding-left: 20px;
-		}
+    @include small-and-up {
+      font-size: rem(18);
+      margin-bottom: 32px;
+      padding-left: 20px;
+    }
 
-		@include large-and-up {
-			margin-bottom: 45px;
-			padding-left: 30px;
-		}
+    @include large-and-up {
+      margin-bottom: 45px;
+      padding-left: 30px;
+    }
 
-		@include x-large-and-up {
-			font-size: rem(22);
-			margin-bottom: 40px;
-			padding-left: 50px;
-		}
-	}
+    @include x-large-and-up {
+      font-size: rem(22);
+      margin-bottom: 40px;
+      padding-left: 50px;
+    }
+  }
 }


### PR DESCRIPTION
This fixes issue 45 from the sheet.

It's actually a small fix, but the diff got bugger because `_search.scss` had tabs instead of spaces.