### PR TITLE
Fix spacing on county list menu

### DIFF
--- a/src/scss/common/_navbar.scss
+++ b/src/scss/common/_navbar.scss
@@ -440,7 +440,8 @@ $menu-height-large: rem(60);
   text-transform: none;
   background: $dark-tiber;
   line-height: 1.5;
-  padding: 1.5em 0;
+  padding: 1.4em 0;
+  margin-top: -1px;
 
   &.open {
     display: block;


### PR DESCRIPTION
This fixes issue 122 from sheet. On some mobile browsers there is a one pixel space between the `country-list` dropdown and the navbar.