### PR TITLE
Bug/1633 take action covers

### DIFF
--- a/act.html
+++ b/act.html
@@ -294,6 +294,24 @@
           <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
           <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
         </div>
+        <div class="cover-card card-one" style="background-image: url( 'images/covers-card-one.png');">
+          <a href="#"  class="cover-card-tag">#HashTag</a>
+          <h2 class="cover-card-heading">Show you’re a food warrior</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
+        <div class="cover-card card-two dark-card-bg" style="background-image: url( 'images/covers-card-two.png');">
+          <a href="#"  class="cover-card-tag">#HashTag</a>
+          <h2 class="cover-card-heading">Sumatran Tiger</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
+        <div class="cover-card card-one" style="background-image: url( 'images/covers-card-one.png');">
+          <a href="#" class="cover-card-tag">#HashTag</a>
+          <h2 class="cover-card-heading">Show you’re a food warrior</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
 
         <div class="col-lg-4 col-md-6 mb-5">
           <button class="btn btn-block btn-small btn-secondary">Load More ...</button>
@@ -324,6 +342,24 @@
         </div>
         <div class="cover-card cover-card--evergreen card-three dark-card-bg" style="background-image: url( 'images/rainbow-warrior-cover.jpg');">
           <a href="#"  class="cover-card-tag">#RainbowWarrior</a>
+          <h2 class="cover-card-heading">Sail aboard a Greenpeace ship</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
+        <div class="cover-card cover-card--evergreen card-two dark-card-bg" style="background-image: url( 'images/rainbow-warrior-cover.jpg');">
+          <a href="#"  class="cover-card-tag">#RainbowWarrior</a>
+          <h2 class="cover-card-heading">Sail aboard a Greenpeace ship</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
+        <div class="cover-card cover-card--evergreen card-three dark-card-bg" style="background-image: url( 'images/rainbow-warrior-cover.jpg');">
+          <a href="#"  class="cover-card-tag">#RainbowWarrior</a>
+          <h2 class="cover-card-heading">Sail aboard a Greenpeace ship</h2>
+          <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
+          <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>
+        </div>
+        <div class="cover-card cover-card--evergreen card-one" style="background-image: url( 'images/rainbow-warrior-cover.jpg');">
+          <a href="#" class="cover-card-tag">#RainbowWarrior</a>
           <h2 class="cover-card-heading">Sail aboard a Greenpeace ship</h2>
           <p>Cupcake cookie cotton candy chocolate cake oat ice sweet roll pastry croissant toffee mufﬁn tiramisu. Marsh mallow tootsie roll sugar plum powder oatcake gingerbread. </p>
           <button class="btn btn-action btn-block cover-card-btn">TAKE ACTION</button>

--- a/src/scss/common/_covers.scss
+++ b/src/scss/common/_covers.scss
@@ -4,6 +4,20 @@
   justify-content: space-between;
 }
 
+// Visibility  of covers in different screens 
+// S,M should have 4 covers
+// L & XL should have all sent from backend
+
+.cover-card:nth-child(n+5) {
+  display: none;
+}
+
+@include large-and-up {
+  .cover-card:nth-child(n+5) {
+    display: block;
+  }
+}
+
 .cover-card {
   min-height: 440px;
   flex-basis: 100%;


### PR DESCRIPTION
Fix for https://jira.greenpeace.org/browse/PLANET-1633

by default, please have 6 Take Action covers show for L and XL screens
by default, please have 4 Take Action covers show for M screen

if it's possible to determine this on a page-by-page basis, I would like all available covers appearing on the [Act|https://dev.p4.greenpeace.org/international/act/|https://dev.p4.greenpeace.org/international/act/] page for L and XL screens

_NO MARKUP CHANGES HERE_
