### PR TITLE
Fix for 1596

### DIFF
--- a/src/scss/pages/post/_article-content.scss
+++ b/src/scss/pages/post/_article-content.scss
@@ -23,7 +23,14 @@
     margin: 15px 0;
 
     iframe {
-      max-width: 100%;
+      width: 100%;
+      height: 503px;
+      text-align: center;
+      display: block;
+      margin: 0 auto;
+      @include large-and-up {
+        width: 840px;
+      }
     }
 
     @include small-and-up {


### PR DESCRIPTION
Bug: video widths are not expanding for desktop when pasting YouTube URL into text or when adding via Add Media > Insert from URL.

Assumption while fixing: the video embed with the shortcake plugin produces the right results.