### PR TITLE
Static four column links changes

### DIFF
--- a/src/scss/common/_static-four-column.scss
+++ b/src/scss/common/_static-four-column.scss
@@ -95,10 +95,6 @@
 
     a {
       font-weight: 700;
-
-      &::after {
-        display: none;
-      }
     }
 
     @include medium-and-up {
@@ -137,7 +133,6 @@
   }
 
   a {
-    font-weight: normal;
 
     @include medium-and-up {
       font-size: rem(15);
@@ -153,11 +148,6 @@
 
     &:hover {
       text-decoration: underline;
-    }
-
-    &::after {
-      content: "\203A";
-      padding-left: 5px;
     }
   }
 }


### PR DESCRIPTION
Remove > character in static four column links and make links bold.
[comment on issue 1623 ](https://jira.greenpeace.org/browse/PLANET-1623?focusedCommentId=60776&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-60776)