### PR TITLE
Fix for PLANET-1655

### DIFF
--- a/post.html
+++ b/post.html
@@ -906,12 +906,28 @@
             <button class="btn btn-small btn-secondary comment-reply-btn">Reply</button>
           </footer>
         </article>
-        <article class="single-comment">
-               <p itemprop="commentText" class="single-comment-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <article class="single-comment comment-level-1">
+          <p itemprop="commentText" class="single-comment-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           <footer class="single-comment-meta">
             <span class="author-info" itemprop="author">Name</span>
             <time datetime="" class="comment-date" itemprop="commentTime">Date</time>
             <button class="btn btn-small btn-secondary comment-reply-btn">Reply</button>
+          </footer>
+        </article>
+        <article class="single-comment comment-level-2">
+          <p itemprop="commentText" class="single-comment-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <footer class="single-comment-meta">
+            <span class="author-info" itemprop="author">Name</span>
+              <time datetime="" class="comment-date" itemprop="commentTime">Date</time>
+              <button class="btn btn-small btn-secondary comment-reply-btn">Reply</button>
+          </footer>
+        </article>
+        <article class="single-comment comment-level-3">
+          <p itemprop="commentText" class="single-comment-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <footer class="single-comment-meta">
+            <span class="author-info" itemprop="author">Name</span>
+              <time datetime="" class="comment-date" itemprop="commentTime">Date</time>
+              <button class="btn btn-small btn-secondary comment-reply-btn">Reply</button>
           </footer>
         </article>
       </section>

--- a/src/scss/pages/post/_comments-block.scss
+++ b/src/scss/pages/post/_comments-block.scss
@@ -37,8 +37,12 @@
   }
 }
 
+// Adds nesting on comments
+@include comment-level;
+
 .single-comment {
-  margin: 16px 0;
+  margin-top: 16px;
+  margin-bottom: 16px;
   padding-bottom: 16px;
   border-bottom: 1px solid $grey-20;
   font-size: rem(14);
@@ -49,7 +53,8 @@
   }
 
   @include medium-and-up {
-    margin: 22px 0;
+    margin-top: 22px;
+    margin-bottom: 22px;
     padding-bottom: 24px;
   }
 }

--- a/src/scss/partials/_mixins.scss
+++ b/src/scss/partials/_mixins.scss
@@ -220,3 +220,19 @@ $baseFontSize : 16;
 
   @return $pixels / $context * 1rem;
 }
+
+/* Generates mutilevel nested comments 
+  level-1 is the first level comment with a margin of 50px
+  level-2 is the first level comment with a margin of 100px
+  and so on...
+*/
+$comment-nest-level: 6;
+$nested-comment-left-margin: 50px;
+
+@mixin comment-level {
+  @for $i from 1 through $comment-nest-level {
+    .comment-level-#{$i} {
+      margin-left: $nested-comment-left-margin * $i !important;
+    }
+  }
+}


### PR DESCRIPTION
Added provision for nested comments

Added a mixin which generated classes to be added on comments as per the
nested level eg `comment-level-1` & `comment-level-2` and so on..

@comzeradd Although I have explicitly converted the `margin: 20px 0;` to `margin-top` & `margin-bottom` but still I have added `!important` for the `margin-right` in the mixin we never know if in future someone adds these props and end up overriding our comments `margin-left`. Thoughts? 